### PR TITLE
Double quote "troposphere[policy]" to avoid error in Z shell

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ To install troposphere with `awacs <https://github.com/cloudtools/awacs>`_
 
 .. code:: sh
 
-    $ pip install troposphere[policy]
+    $ pip install "troposphere[policy]"
 
 Alternatively, you can run use setup.py to install by cloning this repository
 and issuing:


### PR DESCRIPTION
when executing `pip install troposphere[policy]` in Z shell fails with:
`zsh: no matches found: troposphere[policy]`

Maybe related to the `[` and `]` characters.
Solved by double quoting the parameter: `pip install "troposphere[policy]"`

Thank you,

Eduardo Leggiero